### PR TITLE
Fix invalid return value from Hare.Core.Conn.open_channel/1 after disconnect

### DIFF
--- a/lib/hare/core/conn/state.ex
+++ b/lib/hare/core/conn/state.ex
@@ -37,14 +37,11 @@ defmodule Hare.Core.Conn.State do
     {:retry, interval, %{state | bridge: new_bridge}}
   end
 
-  defp handle_open_channel({:ok, given_chan}, %{bridge: bridge}, _client) do
-    {:ok, Chan.new(given_chan, bridge.adapter)}
-  end
   defp handle_open_channel(:not_connected, %{waiting: waiting} = state, client) do
     {:wait, %{state | waiting: Waiting.push(waiting, client)}}
   end
-  defp handle_open_channel({:error, _reason} = error, _state, _client) do
-    error
+  defp handle_open_channel(result, _state, _client) do
+    result
   end
 
   defp reply_waiting(clients, bridge, reply) do

--- a/test/hare/core/conn/state/bridge_test.exs
+++ b/test/hare/core/conn/state/bridge_test.exs
@@ -1,6 +1,7 @@
 defmodule Hare.Core.Conn.State.BridgeTest do
   use ExUnit.Case, async: true
 
+  alias Hare.Core.Chan
   alias Hare.Core.Conn.State.Bridge
   alias Hare.Adapter.Sandbox, as: Adapter
 
@@ -26,7 +27,7 @@ defmodule Hare.Core.Conn.State.BridgeTest do
     assert {:ok, bridge} = Bridge.connect(bridge)
     assert %{status: :connected, given: given_1, ref: ref_1} = bridge
 
-    assert {:ok, given_chan} = Bridge.open_channel(bridge)
+    assert {:ok, %Chan{given: given_chan}} = Bridge.open_channel(bridge)
 
     Adapter.Backdoor.unlink(given_chan)
     Adapter.Backdoor.unlink(bridge.given)

--- a/test/hare/core/conn_test.exs
+++ b/test/hare/core/conn_test.exs
@@ -50,7 +50,7 @@ defmodule Hare.Core.ConnTest do
     assert nil == Task.yield(task_1, 0)
     assert nil == Task.yield(task_2, 0)
 
-    {:ok, _channel} = Task.await(task_1)
-    {:ok, _channel} = Task.await(task_2)
+    {:ok, _channel = %Chan{}} = Task.await(task_1)
+    {:ok, _channel = %Chan{}} = Task.await(task_2)
   end
 end


### PR DESCRIPTION
This commit fixes following incorrect behaviour:

If `Hare.Core.Conn.open_channel/1` was called during reconnection phase,
calling process will receive `%AMQP.Channel{}` instead of expected `%Hare.Core.Chan{}`
after connection has been established.