### PR TITLE
Allow publish messages to default exchange in RPC client

### DIFF
--- a/lib/hare/rpc/client/declaration.ex
+++ b/lib/hare/rpc/client/declaration.ex
@@ -19,13 +19,18 @@ defmodule Hare.RPC.Client.Declaration do
   end
 
   defp steps(config) do
-    with {:ok, exchange_config} <- Keyword.fetch(config, :exchange),
-         true                   <- Keyword.keyword?(exchange_config) do
+    with exchange_config <- Keyword.get(config, :exchange, []),
+         true            <- Keyword.keyword?(exchange_config) do
       {:ok, build_steps(exchange_config)}
     else
       :error -> {:error, {:not_present, :exchange}}
       false  -> {:error, {:not_keyword_list, :exchange}}
     end
+  end
+
+  defp build_steps([]) do
+    [@response_queue_step,
+     default_exchange: [{:export_as, :request_exchange}]]
   end
 
   defp build_steps(exchange_config) do


### PR DESCRIPTION
Hello,

I'm building a custom AMQP RPC Client and considering your library as a basis. Current `Hare.RPC.Client` almost fits our needs except couple of things:
1) In our cluster we use default exchange to pass messages between the nodes. Currently `Hare.RPC.Client` requires non-default exchange, which is, unfortunately, not an option for us. This problem should be solved in this PR.
2) We need to handle messages that cannot be delivered to desired destination (could be achieved with [`:amqp_channel.register_return_handler/2`](https://github.com/jbrisbin/amqp_client/blob/master/src/amqp_channel.erl#L276)). Do you think it worth adding this feature to Hare or should I add it only to custom client?

P.S. This library is awesome! I've learned a lot about Elixir by reading your code.