### PR TITLE
Fix typespecs.

### DIFF
--- a/lib/hare/consumer.ex
+++ b/lib/hare/consumer.ex
@@ -237,7 +237,7 @@ defmodule Hare.Consumer do
     * `initial` - the value that will be given to `init/1`
     * `opts` - the GenServer options
   """
-  @spec start_link(module, pid, config, initial :: term, GenServer.options) :: GenServer.on_start
+  @spec start_link(module, GenServer.server, config, initial :: term, GenServer.options) :: GenServer.on_start
   def start_link(mod, conn, config, initial, opts \\ []) do
     {context, opts} = Keyword.pop(opts, :context, @context)
     args = {mod, conn, config, context, initial}

--- a/lib/hare/context/action/bind.ex
+++ b/lib/hare/context/action/bind.ex
@@ -44,12 +44,12 @@ defmodule Hare.Context.Action.Bind do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{optional(:queue)                => binary,
-                    optional(:queue_from_export)    => atom,
-                    optional(:exchange)             => binary,
-                    optional(:exchange_from_export) => atom,
-                    optional(:opts)                 => Keyword.t,
-                    optional(:export_as)            => atom}
+  @type config :: [queue:                binary,
+                   queue_from_export:    atom,
+                   exchange:             binary,
+                   exchange_from_export: atom,
+                   opts:                 Keyword.t,
+                   export_as:            atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/declare_exchange.ex
+++ b/lib/hare/context/action/declare_exchange.ex
@@ -31,10 +31,10 @@ defmodule Hare.Context.Action.DeclareExchange do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{required(:name)      => binary,
-                    optional(:type)      => atom,
-                    optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [name:      binary,
+                   type:      atom,
+                   opts:      Keyword.t,
+                   export_as: atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/declare_queue.ex
+++ b/lib/hare/context/action/declare_queue.ex
@@ -29,9 +29,9 @@ defmodule Hare.Context.Action.DeclareQueue do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{required(:name)      => binary,
-                    optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [name:      binary,
+                   opts:      Keyword.t,
+                   export_as: atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/declare_server_named_queue.ex
+++ b/lib/hare/context/action/declare_server_named_queue.ex
@@ -27,8 +27,8 @@ defmodule Hare.Context.Action.DeclareServerNamedQueue do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [opts:      Keyword.t,
+                   export_as: atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/default_exchange.ex
+++ b/lib/hare/context/action/default_exchange.ex
@@ -28,10 +28,10 @@ defmodule Hare.Context.Action.DefaultExchange do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{required(:name)      => binary,
-                    optional(:type)      => atom,
-                    optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [name:      binary,
+                   type:      atom,
+                   opts:      Keyword.t,
+                   export_as: atom]
   @behaviour Hare.Context.Action
 
   alias Hare.Core.Exchange

--- a/lib/hare/context/action/delete_exchange.ex
+++ b/lib/hare/context/action/delete_exchange.ex
@@ -29,9 +29,9 @@ defmodule Hare.Context.Action.DeleteExchange do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{required(:name)      => binary,
-                    optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [name:      binary,
+                   opts:      Keyword.t,
+                   export_as: atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/delete_queue.ex
+++ b/lib/hare/context/action/delete_queue.ex
@@ -29,9 +29,9 @@ defmodule Hare.Context.Action.DeleteQueue do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{required(:name)      => binary,
-                    optional(:opts)      => Keyword.t,
-                    optional(:export_as) => atom}
+  @type config :: [name:      binary,
+                   opts:      Keyword.t,
+                   export_as: atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/context/action/unbind.ex
+++ b/lib/hare/context/action/unbind.ex
@@ -44,12 +44,12 @@ defmodule Hare.Context.Action.Unbind do
   """
 
   @typedoc "The action configuration"
-  @type config :: %{optional(:queue)                => binary,
-                    optional(:queue_from_export)    => atom,
-                    optional(:exchange)             => binary,
-                    optional(:exchange_from_export) => atom,
-                    optional(:opts)                 => Keyword.t,
-                    optional(:export_as)            => atom}
+  @type config :: [queue:                binary,
+                   queue_from_export:    atom,
+                   exchange:             binary,
+                   exchange_from_export: atom,
+                   opts:                 Keyword.t,
+                   export_as:            atom]
 
   @behaviour Hare.Context.Action
 

--- a/lib/hare/publisher.ex
+++ b/lib/hare/publisher.ex
@@ -202,7 +202,7 @@ defmodule Hare.Publisher do
     * `initial` - the value that will be given to `init/1`
     * `opts` - the GenServer options
   """
-  @spec start_link(module, pid, config, initial :: term, GenServer.options) :: GenServer.on_start
+  @spec start_link(module, GenServer.server, config, initial :: term, GenServer.options) :: GenServer.on_start
   def start_link(mod, conn, config, initial, opts \\ []) do
     {context, opts} = Keyword.pop(opts, :context, @context)
     args = {mod, conn, config, context,  initial}
@@ -213,7 +213,7 @@ defmodule Hare.Publisher do
   @doc """
   Publishes a message to an exchange through the `Hare.Publisher` process.
   """
-  @spec publish(pid, payload, routing_key, opts) :: :ok
+  @spec publish(GenServer.server, payload, routing_key, opts) :: :ok
   def publish(client, payload, routing_key \\ "", opts \\ []),
     do: Connection.cast(client, {:publication, payload, routing_key, opts})
 

--- a/lib/hare/rpc/client.ex
+++ b/lib/hare/rpc/client.ex
@@ -231,7 +231,7 @@ defmodule Hare.RPC.Client do
     * `initial` - the value that will be given to `init/1`
     * `opts` - the GenServer options
   """
-  @spec start_link(module, pid, config, initial :: term, GenServer.options) :: GenServer.on_start
+  @spec start_link(module, GenServer.server, config, initial :: term, GenServer.options) :: GenServer.on_start
   def start_link(mod, conn, config, initial, opts \\ []) do
     {context, opts} = Keyword.pop(opts, :context, @context)
     args = {mod, conn, config, context,  initial}
@@ -245,7 +245,7 @@ defmodule Hare.RPC.Client do
   A timeout bound to the same rules as the `GenServer` timeout may be
   specified (5 seconds by default)
   """
-  @spec request(pid, payload, routing_key, opts, timeout) ::
+  @spec request(GenServer.server, payload, routing_key, opts, timeout) ::
           {:ok, response :: binary} |
           {:error, reason :: term}
   def request(client, payload, routing_key \\ "", opts \\ [], timeout \\ 5000),

--- a/lib/hare/rpc/server.ex
+++ b/lib/hare/rpc/server.ex
@@ -226,7 +226,7 @@ defmodule Hare.RPC.Server do
     * `initial` - the value that will be given to `init/1`
     * `opts` - the GenServer options
   """
-  @spec start_link(module, pid, config, initial :: term, GenServer.options) :: GenServer.on_start
+  @spec start_link(module, GenServer.server, config, initial :: term, GenServer.options) :: GenServer.on_start
   def start_link(mod, conn, config, initial, opts \\ []) do
     {context, opts} = Keyword.pop(opts, :context, @context)
     args = {mod, conn, config, context, initial}


### PR DESCRIPTION
Hi! We're using dialyxir in our code to typecheck. Found a few issues:

- Instead of `pid`, which specifically means just a pid, we should be using `GenServer.server` in most cases. Which can either be a `pid | name | ...`, since the most common usecase is to pass in an atom name.

- Most typespecs for options used the map variant, but the functions actually use keyword lists. We do lose the required vs. optional typing (not possible with kwlists), but if we need that, then the code should probably just be switched over to maps.