### PR TITLE
Remove the is_pid check.

### DIFF
--- a/lib/hare/actor/state.ex
+++ b/lib/hare/actor/state.ex
@@ -7,7 +7,7 @@ defmodule Hare.Actor.State do
              :mod, :given]
 
   def new(conn, mod, given)
-  when is_pid(conn) and is_atom(mod) do
+  when is_atom(mod) do
     %State{conn: conn, mod: mod, given: given}
   end
 


### PR DESCRIPTION
If we pass in a name for the conn instead of a pid, the initialization will fail.

e.g.:

```
    Hare.Publisher.start_link(__MODULE__, MyApp.RabbitConn, @config, :ok, name: __MODULE__)
```