### PR TITLE
Relax some typespecs + change "amqp" dependency

### DIFF
--- a/lib/hare/publisher.ex
+++ b/lib/hare/publisher.ex
@@ -49,9 +49,10 @@ defmodule Hare.Publisher do
   Every time a channel is open the context is set up, meaning that the exchange
   is declared through the new channel based on the given configuration.
 
-  The configuration must be a `Keyword.t` that contains a single key: `:exchange`
+  The configuration must be a `Keyword.t` that may contain a single key: `:exchange`
   whose value is the configuration for the `Hare.Context.Action.DeclareExchange`.
-  Check it for more detailed information.
+  Check it for more detailed information. If the `:exchange` key is omited, the
+  default exchange will be used.
   """
 
   @type message     :: term
@@ -193,7 +194,8 @@ defmodule Hare.Publisher do
 
   @context Hare.Context
 
-  @type config :: [exchange: Hare.Context.Action.DeclareExchange.config]
+  @type config        :: [config_option]
+  @type config_option :: {:exchange, Hare.Context.Action.DeclareExchange.config}
 
   @doc """
   Starts a `Hare.Publisher` process linked to the current process.

--- a/lib/hare/publisher.ex
+++ b/lib/hare/publisher.ex
@@ -54,6 +54,7 @@ defmodule Hare.Publisher do
   Check it for more detailed information.
   """
 
+  @type message     :: term
   @type payload     :: Hare.Adapter.payload
   @type routing_key :: Hare.Adapter.routing_key
   @type opts        :: Hare.Adapter.opts
@@ -103,7 +104,7 @@ defmodule Hare.Publisher do
   main loop and call `terminate(reason, state)` before the process exists with
   reason `reason`.
   """
-  @callback before_publication(payload, routing_key, opts :: term, state) ::
+  @callback before_publication(message, routing_key, opts :: term, state) ::
               {:ok, state} |
               {:ok, payload, routing_key, opts :: term, state} |
               {:ignore, state} |
@@ -135,7 +136,7 @@ defmodule Hare.Publisher do
   main loop and call `terminate(reason, state)` before the process exists with
   reason `reason`.
   """
-  @callback handle_info(message :: term, state) ::
+  @callback handle_info(message, state) ::
               {:noreply, state} |
               {:stop, reason :: term, state}
 
@@ -225,7 +226,7 @@ defmodule Hare.Publisher do
   @doc """
   Publishes a message to an exchange through the `Hare.Publisher` process.
   """
-  @spec publish(GenServer.server, payload, routing_key, opts) :: :ok
+  @spec publish(GenServer.server, payload :: term, routing_key, opts) :: :ok
   def publish(client, payload, routing_key \\ "", opts \\ []),
     do: Hare.Actor.cast(client, {:"$hare_publication", payload, routing_key, opts})
 

--- a/lib/hare/publisher/declaration.ex
+++ b/lib/hare/publisher/declaration.ex
@@ -16,13 +16,16 @@ defmodule Hare.Publisher.Declaration do
   end
 
   defp steps(config) do
-    with {:ok, exchange_config} <- Keyword.fetch(config, :exchange),
-         true                   <- Keyword.keyword?(exchange_config) do
+    with exchange_config <- Keyword.get(config, :exchange, []),
+         true            <- Keyword.keyword?(exchange_config) do
       {:ok, build_steps(exchange_config)}
     else
-      :error -> {:error, {:not_present, :exchange}}
       false  -> {:error, {:not_keyword_list, :exchange}}
     end
+  end
+
+  defp build_steps([]) do
+    [default_exchange: [{:export_as, :exchange}]]
   end
 
   defp build_steps(exchange_config) do

--- a/lib/hare/rpc/client.ex
+++ b/lib/hare/rpc/client.ex
@@ -299,7 +299,7 @@ defmodule Hare.RPC.Client do
   specified (5 seconds by default)
   """
   @spec request(GenServer.server, request, routing_key, opts, timeout) ::
-          {:ok, response :: binary} |
+          {:ok, response} |
           {:error, reason :: term}
   def request(client, payload, routing_key \\ "", opts \\ [], timeout \\ 5000),
     do: Hare.Actor.call(client, {:"$hare_request", payload, routing_key, opts}, timeout)

--- a/lib/hare/rpc/client.ex
+++ b/lib/hare/rpc/client.ex
@@ -358,6 +358,7 @@ defmodule Hare.RPC.Client do
 
       {:ok, new_payload, new_routing_key, new_opts, new_given} ->
         correlation_id = perform(new_payload, new_routing_key, new_opts, state)
+        set_request_timeout(correlation_id, state)
         {:noreply, State.set(state, new_given, correlation_id, from)}
 
       {:reply, response, new_given} ->

--- a/lib/hare/rpc/client.ex
+++ b/lib/hare/rpc/client.ex
@@ -267,7 +267,8 @@ defmodule Hare.RPC.Client do
 
   @context Hare.Context
 
-  @type config :: [exchange: Hare.Context.Action.DeclareExchange.config]
+  @type config :: [exchange: Hare.Context.Action.DeclareExchange.config,
+                   timeout: timeout]
 
   @doc """
   Starts a `Hare.RPC.Client` process linked to the current process.

--- a/mix.exs
+++ b/mix.exs
@@ -17,7 +17,7 @@ defmodule Hare.Mixfile do
   end
 
   defp deps do
-    [{:amqp, "~> 0.1.4", hex: :amqp19, optional: true},
+    [{:amqp, "~> 0.2.0", optional: true},
      {:connection, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev}]
   end

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,6 @@
-%{"amqp": {:hex, :amqp19, "0.1.5", "0a05693c9ff7cb8f77db3615012882af594fcc2fddc94bd62894b279003ab406", [:mix], [{:amqp_client, "3.6.2", [hex: :conduit_amqp_client, optional: false]}]},
-  "amqp_client": {:hex, :conduit_amqp_client, "3.6.2", "1f39c67c634b0f798a270ffcc8e70fff93bba8f9857b9ba03857a3394962a320", [:rebar3], [{:rabbit_common, "3.5.6", [hex: :rabbit_common, optional: false]}]},
-  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], []},
-  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], []},
-  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, optional: false]}]},
-  "rabbit_common": {:hex, :rabbit_common, "3.5.6", "ad541be86f08cdb1c04320eb4353ad30f25555569c95cc062af28cf79b74d085", [:rebar], []}}
+%{"amqp": {:hex, :amqp, "0.2.1", "bba2084129de2bdd0189d6deae6fb1654500e4c9b8be9909bf1b07778d54a58a", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
+  "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
+  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}


### PR DESCRIPTION
* Change `amqp` dependency to `~> 0.2.0`. They support OTP 19 since `0.2.0` so there is no need to use forked version.
* Relax `Hare.Publisher.before_publication/4` first argument typespec. Restricting `payload` argument type to `binary` only doesn't allow to create a publisher that accepts arbitrary payload and then encodes it to JSON in `before_publication` callback.
* Relax `Hare.RPC.Client.response` typespec. In `on_response` callback we can transform response into any Elixir term, `response` typespec must reflect this.