### PR TITLE
When doing graceful shutdown, we need to trap exit to call terminate.

### DIFF
--- a/lib/hare/actor.ex
+++ b/lib/hare/actor.ex
@@ -94,6 +94,7 @@ defmodule Hare.Actor do
   defdelegate reply(from, message),          to: Connection
 
   def init({conn, mod, initial}) do
+    Process.flag(:trap_exit, true)
     case mod.init(initial) do
       {:ok, given} ->
         {:connect, :init, State.new(conn, mod, given)}


### PR DESCRIPTION
On :init.stop, the code would crash, since a gen_server skips terminate
in those cases, unless you trap exits (in which case it gets called).
Terminate then properly closes the channel.

Fixes #7 