### PR TITLE
Add `Hare.Consumer.recover/2`

### DIFF
--- a/lib/hare/adapter/amqp.ex
+++ b/lib/hare/adapter/amqp.ex
@@ -109,6 +109,10 @@ if Code.ensure_loaded?(AMQP) do
       Basic.consume(chan, queue, pid, opts)
     end
 
+    def recover(%Channel{} = chan, opts) do
+      Basic.recover(chan, opts)
+    end
+
     def handle({:basic_consume_ok, meta}),
       do: {:consume_ok, meta}
     def handle({:basic_deliver, payload, meta}),

--- a/lib/hare/adapter/sandbox.ex
+++ b/lib/hare/adapter/sandbox.ex
@@ -122,6 +122,10 @@ defmodule Hare.Adapter.Sandbox do
     register(chan, {:consume, [chan, queue, pid, opts], {:ok, tag}})
   end
 
+  def recover(chan, opts) do
+    register(chan, {:recover, [chan, opts], :ok})
+  end
+
   def handle({:consume_ok, _meta} = message),
     do: message
   def handle({:deliver, _payload, _meta} = message),

--- a/lib/hare/adapter/sandbox/backdoor.ex
+++ b/lib/hare/adapter/sandbox/backdoor.ex
@@ -201,7 +201,7 @@ defmodule Hare.Adapter.Sandbox.Backdoor do
   Provokes a connection or a channel process to stop with the given reason,
   therefore triggering all monitors and links with that process.
   """
-  @spec unlink(Conn.t | Chan.t) :: true
+  @spec crash(Conn.t | Chan.t, reason :: term) :: :ok
   def crash(resource, reason \\ :simulated_crash)
 
   def crash(%Conn{} = conn, reason),

--- a/lib/hare/consumer.ex
+++ b/lib/hare/consumer.ex
@@ -351,7 +351,7 @@ defmodule Hare.Consumer do
         handle_mod_message(payload, meta, state)
 
       {:cancel_ok, _meta} ->
-        {:stop, :cancelled, state}
+        {:stop, {:shutdown, :cancelled}, state}
 
       :unknown ->
         handle_async(message, :handle_info, state)

--- a/lib/hare/consumer.ex
+++ b/lib/hare/consumer.ex
@@ -133,6 +133,29 @@ defmodule Hare.Consumer do
               {:stop, reason :: term, state}
 
   @doc """
+  Called when the process receives a call message sent by `call/3`. This
+  callback has the same arguments as the `GenServer` equivalent and the
+  `:reply`, `:noreply` and `:stop` return tuples behave the same.
+  """
+  @callback handle_call(request :: term, GenServer.from, state) ::
+    {:reply, reply :: term, state} |
+    {:reply, reply :: term, state, timeout | :hibernate} |
+    {:noreply, state} |
+    {:noreply, state, timeout | :hibernate} |
+    {:stop, reason :: term, state} |
+    {:stop, reason :: term, reply :: term, state}
+
+  @doc """
+  Called when the process receives a cast message sent by `cast/3`. This
+  callback has the same arguments as the `GenServer` equivalent and the
+  `:noreply` and `:stop` return tuples behave the same.
+  """
+  @callback handle_cast(request :: term, state) ::
+    {:noreply, state} |
+    {:noreply, state, timeout | :hibernate} |
+    {:stop, reason :: term, state}
+
+  @doc """
   Called when the process receives a message.
 
   Returning `{:noreply, state}` will causes the process to enter the main loop
@@ -243,6 +266,16 @@ defmodule Hare.Consumer do
   @spec reject(meta, opts) :: :ok
   def reject(%{queue: queue} = meta, opts \\ []),
     do: Queue.reject(queue, meta, opts)
+
+  @doc """
+  Redeliver messages that weren't acknowledged by a specified consumer.
+
+  Options are dependent on an underlying adapter. For RabbitMQ, `{:requeue, true}`
+  option must be specified.
+  """
+  @spec recover(meta, opts) :: term
+  def recover(%{queue: queue} = _meta, opts \\ []),
+    do: Queue.recover(queue, opts)
 
   defdelegate call(server, message),          to: Hare.Actor
   defdelegate call(server, message, timeout), to: Hare.Actor

--- a/lib/hare/core/chan.ex
+++ b/lib/hare/core/chan.ex
@@ -20,7 +20,9 @@ defmodule Hare.Core.Chan do
   If the connection is not established, it blocks until it is established.
   A timeout in ms may be specified for this operation (5 seconds by default).
   """
-  @spec open(conn :: pid, timeout) :: t
+  @spec open(conn :: GenServer.server, timeout) ::
+          {:ok, t} |
+          {:error, reason :: term}
   def open(conn, timeout \\ 5000) do
     Hare.Core.Conn.open_channel(conn, timeout)
   end

--- a/lib/hare/core/conn.ex
+++ b/lib/hare/core/conn.ex
@@ -49,8 +49,8 @@ defmodule Hare.Core.Conn do
 
   A timeout can be given to `GenServer.call/3`.
   """
-  @spec open_channel(conn :: pid, timeout) :: {:ok, Hare.Core.Chan.t} |
-                                              {:error, reason :: term}
+  @spec open_channel(conn :: GenServer.server, timeout) :: {:ok, Hare.Core.Chan.t} |
+                                                           {:error, reason :: term}
   def open_channel(conn, timeout \\ 5000),
     do: Connection.call(conn, :open_channel, timeout)
 

--- a/lib/hare/core/conn/state/bridge.ex
+++ b/lib/hare/core/conn/state/bridge.ex
@@ -43,8 +43,8 @@ defmodule Hare.Core.Conn.State.Bridge do
               config:         adapter_config,
               backoff:        backoff,
               next_intervals: backoff,
-              given:          given,
-              ref:            reference,
+              given:          given | nil,
+              ref:            reference | nil,
               status:         status}
 
   defstruct [:adapter, :config,

--- a/lib/hare/core/queue.ex
+++ b/lib/hare/core/queue.ex
@@ -72,8 +72,8 @@ defmodule Hare.Core.Queue do
   # => %Queue{name: "nas=eq3as.ndf?ea", chan: chan}
   ```
   """
-  @spec declare(chan) :: {:ok, info :: term, t} |
-                         {:error, reason :: term}
+  @spec declare(chan, name | opts) :: {:ok, info :: term, t} |
+                                      {:error, reason :: term}
   def declare(chan, name) when is_binary(name),
     do: declare(chan, name, [])
   def declare(%Chan{} = chan, opts) do
@@ -136,7 +136,7 @@ defmodule Hare.Core.Queue do
   the exchange with `Exchange.declare/4` and use the resulting exchange as
   `unbind/3` second argument.
   """
-  @spec bind(t, Exchange.t | binary, opts) :: :ok
+  @spec unbind(t, Exchange.t | binary, opts) :: :ok
   def unbind(queue, exchange_or_name, opts \\ [])
   def unbind(%Queue{chan: chan} = queue, exchange_name, opts)
   when is_binary(exchange_name) do
@@ -193,8 +193,8 @@ defmodule Hare.Core.Queue do
   Otherwise the second argument is interpreted as options. It delegates to
   `consume/3` with the caller's pid and the given options.
   """
-  @spec consume(t, pid, opts) :: {:ok, t} |
-                                 {:error, :already_consuming}
+  @spec consume(t, pid | opts) :: {:ok, t} |
+                                  {:error, :already_consuming}
   def consume(queue, pid) when is_pid(pid), do: consume(queue, pid, [])
   def consume(queue, opts),                 do: consume(queue, self(), opts)
 
@@ -286,6 +286,16 @@ defmodule Hare.Core.Queue do
     %{given: given, adapter: adapter} = chan
 
     adapter.delete_queue(given, name, opts)
+  end
+
+  @doc """
+  Redeliver all unacknowledged messages from a specified queue.
+
+  It delegates the given options to the underlying adapter. The format
+  of these options depends on the adapter.
+  """
+  def recover(%Queue{chan: %{given: given, adapter: adapter}}, opts \\ []) do
+    adapter.recover(given, opts)
   end
 
   defp do_consume(%{given: given, adapter: adapter}, name, pid, opts),

--- a/lib/hare/rpc/client/declaration.ex
+++ b/lib/hare/rpc/client/declaration.ex
@@ -25,7 +25,6 @@ defmodule Hare.RPC.Client.Declaration do
          true            <- Keyword.keyword?(exchange_config) do
       {:ok, build_steps(exchange_config)}
     else
-      :error -> {:error, {:not_present, :exchange}}
       false  -> {:error, {:not_keyword_list, :exchange}}
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,11 @@ defmodule Hare.Mixfile do
      start_permanent: Mix.env == :prod,
      description: "Some abstractions to interact with a AMQP broker",
      package: package(),
-     deps: deps()]
+     deps: deps(),
+     dialyzer: [
+       flags: [:error_handling],
+       remove_defaults: [:unknown]]
+    ]
   end
 
   def application do
@@ -19,7 +23,8 @@ defmodule Hare.Mixfile do
   defp deps do
     [{:amqp, "~> 0.2.0", optional: true},
      {:connection, "~> 1.0"},
-     {:ex_doc, ">= 0.0.0", only: :dev}]
+     {:ex_doc, ">= 0.0.0", only: :dev},
+     {:dialyxir, "~> 0.5", only: :dev, runtime: false}]
   end
 
   defp package do

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,7 @@
 %{"amqp": {:hex, :amqp, "0.2.1", "bba2084129de2bdd0189d6deae6fb1654500e4c9b8be9909bf1b07778d54a58a", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
+  "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
   "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}


### PR DESCRIPTION
This function can be useful in situations when consumers acknowledge
messages manually. In this case, if some messages left unacknowledged
(because of crash, for example), one might want to redeliver all
unacknowldged messages.

Also this commit fixes multiple Dialyzer warnings.