### PR TITLE
Enable setting QoS on the consumer.

### DIFF
--- a/lib/hare/consumer.ex
+++ b/lib/hare/consumer.ex
@@ -202,7 +202,8 @@ defmodule Hare.Consumer do
 
   @type config :: [queue:    Hare.Context.Action.DeclareQueue.config,
                    exchange: Hare.Context.Action.DeclareExchange.config,
-                   bind:     Keyword.t]
+                   bind:     Keyword.t,
+                   qos:      Keyword.t]
 
   @type opts :: Hare.Adapter.opts
 

--- a/lib/hare/consumer/declaration.ex
+++ b/lib/hare/consumer/declaration.ex
@@ -23,8 +23,9 @@ defmodule Hare.Consumer.Declaration do
     with {:ok, exchange_config} <- extract(config, :exchange),
          {:ok, queue_config}    <- extract(config, :queue) do
       binds_opts = get_binds(config)
+      qos_opts = Keyword.get(config, :qos)
 
-      {:ok, build_steps(exchange_config, queue_config, binds_opts)}
+      {:ok, build_steps(exchange_config, queue_config, binds_opts, qos_opts)}
     end
   end
 
@@ -43,7 +44,7 @@ defmodule Hare.Consumer.Declaration do
       do: [[]]
   end
 
-  defp build_steps(exchange_config, queue_config, binds_opts) do
+  defp build_steps(exchange_config, queue_config, binds_opts, qos_opts) do
     resources = [declare_exchange: [{:export_as, :exchange} | exchange_config],
                  declare_queue:    [{:export_as, :queue}    | queue_config]]
 
@@ -51,7 +52,9 @@ defmodule Hare.Consumer.Declaration do
       {:bind, [{:opts, bind_opts} | @bind_exported_resources]}
     end
 
-    resources ++ binds
+    qos = if qos_opts, do: [qos: qos_opts], else: []
+
+    resources ++ binds ++ qos
   end
 
   def run(%Declaration{steps: steps, context: context}, chan) do

--- a/lib/hare/context/action.ex
+++ b/lib/hare/context/action.ex
@@ -75,7 +75,8 @@ defmodule Hare.Context.Action do
            declare_server_named_queue: Action.DeclareServerNamedQueue,
            server_named_queue:         Action.DeclareServerNamedQueue,
            bind:                       Action.Bind,
-           unbind:                     Action.Unbind}
+           unbind:                     Action.Unbind,
+           qos:                        Action.Qos}
 
   @doc false
   def validate(name_or_module, config, known \\ @known) do

--- a/lib/hare/context/action/qos.ex
+++ b/lib/hare/context/action/qos.ex
@@ -1,0 +1,31 @@
+defmodule Hare.Context.Action.Qos do
+  @moduledoc """
+  This module implements a `Hare.Context.Action` behaviour to
+  declare a qos.
+
+  ## Config
+
+  Configuration must be a `Keyword.t` with the following fields:
+
+    * `:prefetch_count` - the number of messages to prefetch
+  """
+
+  @typedoc "The action configuration"
+  @type config :: [prefetch_count: integer]
+
+  @behaviour Hare.Context.Action
+
+  alias Hare.Context.Action.Shared
+  alias Hare.Core.Chan
+
+  import Hare.Context.Action.Helper.Validations,
+    only: [validate: 4]
+
+  def validate(config) do
+    validate(config, :prefetch_count, :integer, required: true)
+  end
+
+  def run(chan, config, exports) do
+    Chan.qos(chan, prefetch_count: config[:prefetch_count])
+  end
+end


### PR DESCRIPTION
The qos method is already available on the Queue, and even has a few tests, but isn't exposed anywhere. We really needed this in combination with the asynchronous ACKs (`Hare.Consumer.ack(meta)`), because we have a bunch of slow jobs where we have to wait for the success confirmation before we can ACK them.

---

On another note, these declarations are tricky to integrate with especially since Consumer/Publisher have a strict list of actions you can run (and then the code needs to sort these actions in order, etc...). I think it would be much nicer if `Consumer|Publisher.declare/2` called `declare/2` in our module (or if it was at least defoverridable from the module) -- that way the user can at least access some of the unavailable features with the raw adapter/AMQP library instead of needing to wrap everything into actions.