### PR TITLE
Add 'on_return' callback to Hare.RPC.Client

### DIFF
--- a/lib/hare/adapter/amqp.ex
+++ b/lib/hare/adapter/amqp.ex
@@ -113,12 +113,22 @@ if Code.ensure_loaded?(AMQP) do
       Basic.recover(chan, opts)
     end
 
+    def register_return_handler(%Channel{} = chan, pid) do
+      Basic.return(chan, pid)
+    end
+
+    def unregister_return_handler(%Channel{} = chan) do
+      Basic.cancel_return(chan)
+    end
+
     def handle({:basic_consume_ok, meta}),
       do: {:consume_ok, meta}
     def handle({:basic_deliver, payload, meta}),
       do: {:deliver, payload, meta}
     def handle({:basic_cancel_ok, meta}),
       do: {:cancel_ok, meta}
+    def handle({:basic_return, payload, meta}),
+      do: {:return, payload, meta}
     def handle(_message),
       do: :unknown
 

--- a/lib/hare/adapter/sandbox.ex
+++ b/lib/hare/adapter/sandbox.ex
@@ -126,11 +126,21 @@ defmodule Hare.Adapter.Sandbox do
     register(chan, {:recover, [chan, opts], :ok})
   end
 
+  def register_return_handler(chan, pid) do
+    register(chan, {:register_return_handler, [chan, pid], :ok})
+  end
+
+  def unregister_return_handler(chan) do
+    register(chan, {:unregister_return_handler, [chan], :ok})
+  end
+
   def handle({:consume_ok, _meta} = message),
     do: message
   def handle({:deliver, _payload, _meta} = message),
     do: message
   def handle({:cancel_ok, _meta} = message),
+    do: message
+  def handle({:return, _payload, _meta} = message),
     do: message
   def handle(_message),
     do: :unknown

--- a/lib/hare/context/action/qos.ex
+++ b/lib/hare/context/action/qos.ex
@@ -15,7 +15,6 @@ defmodule Hare.Context.Action.Qos do
 
   @behaviour Hare.Context.Action
 
-  alias Hare.Context.Action.Shared
   alias Hare.Core.Chan
 
   import Hare.Context.Action.Helper.Validations,
@@ -25,7 +24,7 @@ defmodule Hare.Context.Action.Qos do
     validate(config, :prefetch_count, :integer, required: true)
   end
 
-  def run(chan, config, exports) do
+  def run(chan, config, _exports) do
     Chan.qos(chan, prefetch_count: config[:prefetch_count])
   end
 end

--- a/lib/hare/core/chan.ex
+++ b/lib/hare/core/chan.ex
@@ -80,4 +80,19 @@ defmodule Hare.Core.Chan do
   @spec close(t) :: :ok
   def close(%Chan{given: given, adapter: adapter}),
     do: adapter.close_channel(given)
+
+  @doc """
+  Register a handler to deal with returned messages.
+  """
+  @spec register_return_handler(t) :: :ok
+  def register_return_handler(%Chan{given: given, adapter: adapter}, pid \\ self()),
+    do: adapter.register_return_handler(given, pid)
+
+  @doc """
+  Remove the return handler, if it exists. Does nothing if there is no
+  such handler.
+  """
+  @spec unregister_return_handler(t) :: :ok
+  def unregister_return_handler(%Chan{given: given, adapter: adapter}),
+    do: adapter.unregister_return_handler(given)
 end

--- a/lib/hare/core/queue.ex
+++ b/lib/hare/core/queue.ex
@@ -245,6 +245,7 @@ defmodule Hare.Core.Queue do
   @spec handle(t, message :: term) :: {:consume_ok, meta} |
                                       {:deliver, payload, meta} |
                                       {:cancel_ok, meta} |
+                                      {:return, payload, meta} |
                                       :unknown
   def handle(%Queue{chan: %{adapter: adapter}}, message),
     do: adapter.handle(message)

--- a/mix.exs
+++ b/mix.exs
@@ -21,7 +21,7 @@ defmodule Hare.Mixfile do
   end
 
   defp deps do
-    [{:amqp, "~> 0.2.0", optional: true},
+    [{:amqp, "~> 0.2.2", optional: true},
      {:connection, "~> 1.0"},
      {:ex_doc, ">= 0.0.0", only: :dev},
      {:dialyxir, "~> 0.5", only: :dev, runtime: false}]

--- a/mix.lock
+++ b/mix.lock
@@ -1,7 +1,7 @@
-%{"amqp": {:hex, :amqp, "0.2.1", "bba2084129de2bdd0189d6deae6fb1654500e4c9b8be9909bf1b07778d54a58a", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
-  "amqp_client": {:hex, :amqp_client, "3.6.9", "076d7c68abc670d1bb44bbc357e4fba991a3ab53ce6160ec43576c653849a643", [:make, :rebar3], [{:rabbit_common, "3.6.9", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+%{"amqp": {:hex, :amqp, "0.2.2", "eeb9d832c5440585699ae89f48c38f662a2d44f48e694dfe9ba15824b53da1f9", [:mix], [{:amqp_client, "~> 3.6.8", [hex: :amqp_client, repo: "hexpm", optional: false]}, {:rabbit_common, "~> 3.6.8", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
+  "amqp_client": {:hex, :amqp_client, "3.6.10", "f26fbacca4e71f58eba1a57746e5f10598550aa46e89bc67060da6ad1a6d95d5", [:make, :rebar3], [{:rabbit_common, "3.6.10", [hex: :rabbit_common, repo: "hexpm", optional: false]}], "hexpm"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm"},
   "dialyxir": {:hex, :dialyxir, "0.5.0", "5bc543f9c28ecd51b99cc1a685a3c2a1a93216990347f259406a910cf048d1d7", [:mix], [], "hexpm"},
   "earmark": {:hex, :earmark, "1.0.3", "89bdbaf2aca8bbb5c97d8b3b55c5dd0cff517ecc78d417e87f1d0982e514557b", [:mix], [], "hexpm"},
   "ex_doc": {:hex, :ex_doc, "0.14.5", "c0433c8117e948404d93ca69411dd575ec6be39b47802e81ca8d91017a0cf83c", [:mix], [{:earmark, "~> 1.0", [hex: :earmark, repo: "hexpm", optional: false]}], "hexpm"},
-  "rabbit_common": {:hex, :rabbit_common, "3.6.9", "d54e1bc366f5f553a75055dfc6c93f0025efee0322f98bdf8597aff8482b996d", [:make, :rebar3], [], "hexpm"}}
+  "rabbit_common": {:hex, :rabbit_common, "3.6.10", "2217845381350258c5714c22905ec197af0c4dd38eb3b6a5ddbf55c5bd93f127", [:make, :rebar3], [], "hexpm"}}


### PR DESCRIPTION
`on_return/2` is called whenever a message sent with `mandatory: true`
flag can't be delivered to a given queue. Having such handler reduces
response times in cases when request queue is not available.