### PR TITLE
Improve reconnection mechanism

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,5 @@
+language: elixir
+elixir:
+  - 1.4.2
+otp_release:
+  - 19.3

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,5 @@ elixir:
   - 1.4.5
 otp_release:
   - 19.3
-services:
-  - rabbitmq
-
+script:
+  - mix test --exclude amqp_server

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: elixir
 elixir:
-  - 1.4.2
+  - 1.4.5
 otp_release:
   - 19.3
+services:
+  - rabbitmq
+

--- a/lib/hare/actor/state.ex
+++ b/lib/hare/actor/state.ex
@@ -2,30 +2,37 @@ defmodule Hare.Actor.State do
   alias __MODULE__
   alias Hare.Core.Chan
 
-  defstruct [:conn,
-             :chan, :ref,
+  defstruct [:conn, :status,
+             :chan, :ref, :wait_ref,
              :mod, :given]
 
   def new(conn, mod, given)
   when is_atom(mod) do
-    %State{conn: conn, mod: mod, given: given}
+    %State{conn: conn, mod: mod, given: given, status: :not_connected}
   end
 
   def set(%State{} = state, new_given) do
     %{state | given: new_given}
   end
 
-  def up(%State{conn: conn} = state) do
-    with {:ok, chan} <- Chan.open(conn) do
-      ref = Chan.monitor(chan)
-      new_state = %{state | chan: chan, ref: ref}
-
-      {:ok, new_state}
-    end
+  def open_channel(%State{conn: conn} = state) do
+    conn
+    |> Chan.open()
+    |> handle_open_channel(state)
   end
 
+  def request_channel(%State{conn: conn} = state) do
+    %{ref: ref} = Task.async(Chan, :open, [conn, :infinity])
+    %{state | wait_ref: ref}
+  end
+
+  def handle_open_channel({:ok, chan}, %State{} = state),
+    do: {:ok, connected(state, chan)}
+  def handle_open_channel({:error, reason}, %State{} = state),
+    do: {:error, reason, crash(state)}
+
   def crash(%State{} = state) do
-    %{state | chan: nil, ref: nil}
+    %{state | chan: nil, ref: nil, wait_ref: nil, status: :not_connected}
   end
 
   def down(%State{chan: nil} = state) do
@@ -33,6 +40,11 @@ defmodule Hare.Actor.State do
   end
   def down(%State{chan: chan} = state) do
     Chan.close(chan)
-    %{state | chan: nil, ref: nil}
+    %{state | chan: nil, ref: nil, status: :not_connected}
+  end
+
+  defp connected(state, chan) do
+    ref = Chan.monitor(chan)
+    %{state | chan: chan, ref: ref, wait_ref: nil, status: :connected}
   end
 end

--- a/lib/hare/adapter.ex
+++ b/lib/hare/adapter.ex
@@ -128,12 +128,14 @@ defmodule Hare.Adapter do
     * `{:consume_ok, meta}` - `consume-ok` message sent by the AMQP server when a consumer is started
     * `{:deliver, payload, meta}` - an actual message from the queue being consumed
     * `{:cancel_ok, meta}` - `cancel-ok` message sent by the AMQP server when a consumer is started
+    * `{:cancel, meta}` - `cancel` message sent by the AMQP server when a consumer has been unexpectedly closed
     * `:unknown` - any other message
   """
   @callback handle(message :: term) ::
               {:consume_ok, meta} |
               {:deliver, payload, meta} |
               {:cancel_ok, meta} |
+              {:cancel, meta} |
               :unknown
 
   @doc "Cancels the consumer with the given consumer_tag"

--- a/lib/hare/adapter/amqp.ex
+++ b/lib/hare/adapter/amqp.ex
@@ -127,6 +127,8 @@ if Code.ensure_loaded?(AMQP) do
       do: {:deliver, payload, meta}
     def handle({:basic_cancel_ok, meta}),
       do: {:cancel_ok, meta}
+    def handle({:basic_cancel, meta}),
+      do: {:cancel, meta}
     def handle({:basic_return, payload, meta}),
       do: {:return, payload, meta}
     def handle(_message),

--- a/lib/hare/adapter/sandbox.ex
+++ b/lib/hare/adapter/sandbox.ex
@@ -140,6 +140,8 @@ defmodule Hare.Adapter.Sandbox do
     do: message
   def handle({:cancel_ok, _meta} = message),
     do: message
+  def handle({:cancel, _meta} = message),
+    do: message
   def handle({:return, _payload, _meta} = message),
     do: message
   def handle(_message),

--- a/lib/hare/consumer/state.ex
+++ b/lib/hare/consumer/state.ex
@@ -14,8 +14,11 @@ defmodule Hare.Consumer.State do
            given:       given}
   end
 
-  def declared(%State{} = state, queue, exchange),
+  def connected(%State{} = state, queue, exchange),
     do: %{state | queue: queue, exchange: exchange}
+
+  def disconnected(%State{} = state),
+    do: %{state | queue: nil, exchange: nil}
 
   def set(%State{} = state, given),
     do: %{state | given: given}

--- a/lib/hare/core/queue.ex
+++ b/lib/hare/core/queue.ex
@@ -240,11 +240,13 @@ defmodule Hare.Core.Queue do
     * `{:consume_ok, meta}` - The process has been registered as a consumer and messages from the queue will be sent
     * `{:deliver, payload, meta}` - This is an actual queue message
     * `{:cancel_ok, meta}` - The process has been unregistered as a consumer
+    * `{:cancel, meta}` - The process has been unexpectedly unregistered as a consumer by server
     * `:unknown - The message is not a known AMQP message
   """
   @spec handle(t, message :: term) :: {:consume_ok, meta} |
                                       {:deliver, payload, meta} |
                                       {:cancel_ok, meta} |
+                                      {:cancel, meta} |
                                       {:return, payload, meta} |
                                       :unknown
   def handle(%Queue{chan: %{adapter: adapter}}, message),

--- a/lib/hare/publisher/state.ex
+++ b/lib/hare/publisher/state.ex
@@ -4,18 +4,22 @@ defmodule Hare.Publisher.State do
   alias __MODULE__
 
   defstruct [:config,
-             :declaration, :exchange,
+             :declaration, :exchange, :connected,
              :mod, :given]
 
   def new(config, declaration, mod, given) do
     %State{config:      config,
            declaration: declaration,
+           connected:   false,
            mod:         mod,
            given:       given}
   end
 
-  def declared(%State{} = state, exchange),
-    do: %{state | exchange: exchange}
+  def connected(%State{} = state, exchange),
+    do: %{state | exchange: exchange, connected: true}
+
+  def disconnected(%State{} = state),
+    do: %{state | exchange: nil, connected: false}
 
   def set(%State{} = state, given),
     do: %{state | given: given}

--- a/lib/hare/rpc/client.ex
+++ b/lib/hare/rpc/client.ex
@@ -88,19 +88,46 @@ defmodule Hare.RPC.Client do
               :ignore |
               {:stop, reason :: term}
 
+  @doc """
+  Called when the RPC client process has opened AMQP channel before registering
+  itself as a consumer.
+
+  Returning `{:noreply, state}` will cause the process to enter the main loop
+  with the given state.
+
+  Returning `{:stop, reason, state}` will terminate the main loop and call
+  `terminate(reason, state)` before the process exits with reason `reason`.
+  """
+  @callback handle_connected(state) ::
+              {:noreply, state} |
+              {:stop, reason :: term, state}
 
   @doc """
   Called when the AMQP server has registered the process as a consumer of the
   server-named queue and it will start to receive messages.
 
-  Returning `{:noreply, state}` will causes the process to enter the main loop
+  Returning `{:noreply, state}` will cause the process to enter the main loop
   with the given state.
 
   Returning `{:stop, reason, state}` will not send the message, terminate the
-  main loop and call `terminate(reason, state)` before the process exists with
+  main loop and call `terminate(reason, state)` before the process exits with
   reason `reason`.
   """
   @callback handle_ready(meta, state) ::
+              {:noreply, state} |
+              {:stop, reason :: term, state}
+
+  @doc """
+  Called when the AMQP server has been disconnected from the AMQP broker.
+
+  Returning `{:noreply, state}` will cause the process to enter the main loop
+  with the given state. The server will not consume any new messages until
+  connection to AMQP broker is restored.
+
+  Returning `{:stop, reason, state}` will terminate the main loop and call
+  `terminate(reason, state)` before the process exits with reason `reason`.
+  """
+  @callback handle_disconnected(reason :: term, state) ::
               {:noreply, state} |
               {:stop, reason :: term, state}
 
@@ -125,11 +152,11 @@ defmodule Hare.RPC.Client do
 
   Returning `{:stop, reason, response, state}` will not send the message,
   respond to the caller with `response`, and terminate the main loop
-  and call `terminate(reason, state)` before the process exists with
+  and call `terminate(reason, state)` before the process exits with
   reason `reason`.
 
   Returning `{:stop, reason, state}` will not send the message, terminate the
-  main loop and call `terminate(reason, state)` before the process exists with
+  main loop and call `terminate(reason, state)` before the process exits with
   reason `reason`.
   """
   @callback before_request(request, routing_key, opts :: term, from, state) ::
@@ -155,10 +182,10 @@ defmodule Hare.RPC.Client do
 
   Returning `{:stop, reason, reply, state}` will deliver the given reply to
   the caller instead of the original response and call `terminate(reason, state)`
-  before the process exists with reason `reason`.
+  before the process exits with reason `reason`.
 
   Returning `{:stop, reason, state}` not reply to the caller and call
-  `terminate(reason, state)` before the process exists with reason `reason`.
+  `terminate(reason, state)` before the process exits with reason `reason`.
   """
   @callback on_response(response, from, state) ::
               {:reply, response, state} |
@@ -168,7 +195,7 @@ defmodule Hare.RPC.Client do
 
   @doc """
   Called when a message has been returned. It may happen when a request is sent
-  with option `mandatory: true` and broken cannot deliver the message to a queue.
+  with option `mandatory: true` and broker cannot deliver the message to a queue.
 
   It receives as argument the  caller reference and the internal state.
 
@@ -182,10 +209,10 @@ defmodule Hare.RPC.Client do
 
   Returning `{:stop, reason, reply, state}` will deliver the given reply to
   the caller instead of the original response and call `terminate(reason, state)`
-  before the process exists with reason `reason`.
+  before the process exits with reason `reason`.
 
   Returning `{:stop, reason, state}` not reply to the caller and call
-  `terminate(reason, state)` before the process exists with reason `reason`.
+  `terminate(reason, state)` before the process exits with reason `reason`.
   """
   @callback on_return(payload, state) ::
               {:reply, response, state} |
@@ -207,16 +234,39 @@ defmodule Hare.RPC.Client do
   forever if the timeout was set to `:infinity`).
 
   Returning `{:stop, reason, reply, state}` will deliver the given reply to
-  the caller, and call `terminate(reason, state)` before the process exists
+  the caller, and call `terminate(reason, state)` before the process exits
   with reason `reason`.
 
   Returning `{:stop, reason, state}` will not reply to the caller and call
-  `terminate(reason, state)` before the process exists with reason `reason`.
+  `terminate(reason, state)` before the process exits with reason `reason`.
   """
   @callback on_timeout(from, state) ::
               {:reply, response, state} |
               {:noreply, state} |
               {:stop, reason :: term, response, state} |
+              {:stop, reason :: term, state}
+
+  @doc """
+  Called when the process receives a call message sent by `call/3`. This
+  callback has the same arguments as the `GenServer` equivalent and the
+  `:reply`, `:noreply` and `:stop` return tuples behave the same.
+  """
+  @callback handle_call(request :: term, GenServer.from, state) ::
+              {:reply, reply :: term, state} |
+              {:reply, reply :: term, state, timeout | :hibernate} |
+              {:noreply, state} |
+              {:noreply, state, timeout | :hibernate} |
+              {:stop, reason :: term, state} |
+              {:stop, reason :: term, reply :: term, state}
+
+  @doc """
+  Called when the process receives a cast message sent by `cast/3`. This
+  callback has the same arguments as the `GenServer` equivalent and the
+  `:noreply` and `:stop` return tuples behave the same.
+  """
+  @callback handle_cast(request :: term, state) ::
+              {:noreply, state} |
+              {:noreply, state, timeout | :hibernate} |
               {:stop, reason :: term, state}
 
   @doc """
@@ -226,7 +276,7 @@ defmodule Hare.RPC.Client do
   with the given state.
 
   Returning `{:stop, reason, state}` will not send the message, terminate the
-  main loop and call `terminate(reason, state)` before the process exists with
+  main loop and call `terminate(reason, state)` before the process exits with
   reason `reason`.
   """
   @callback handle_info(meta, state) ::
@@ -250,7 +300,15 @@ defmodule Hare.RPC.Client do
         do: {:ok, initial}
 
       @doc false
+      def handle_connected(state),
+        do: {:noreply, state}
+
+      @doc false
       def handle_ready(_meta, state),
+        do: {:noreply, state}
+
+      @doc false
+      def handle_disconnected(_reason, state),
         do: {:noreply, state}
 
       @doc false
@@ -285,7 +343,8 @@ defmodule Hare.RPC.Client do
       def terminate(_reason, _state),
         do: :ok
 
-      defoverridable [init: 1, terminate: 2, handle_ready: 2,
+      defoverridable [init: 1, terminate: 2,
+                      handle_connected: 1, handle_ready: 2, handle_disconnected: 2,
                       handle_call: 3, handle_cast: 2, handle_info: 2,
                       before_request: 5, on_timeout: 2, on_return: 2, on_response: 3]
     end
@@ -372,17 +431,39 @@ defmodule Hare.RPC.Client do
   end
 
   @doc false
-  def declare(chan, %{declaration: declaration} = state) do
-    with {:ok, resp_queue, req_exchange} <- Declaration.run(declaration, chan),
+  def connected(chan, %{declaration: declaration, mod: mod, given: given} = state) do
+    with {:noreply, new_given}           <- mod.handle_connected(given),
+         new_state                       <- State.set(state, new_given),
+         {:ok, resp_queue, req_exchange} <- Declaration.run(declaration, chan),
          {:ok, new_resp_queue}           <- Queue.consume(resp_queue, no_ack: true),
          :ok                             <- Chan.register_return_handler(chan) do
-      {:ok, State.declared(state, new_resp_queue, req_exchange)}
+      {:ok, State.connected(new_state, chan, new_resp_queue, req_exchange)}
     else
+      {:stop, reason, new_given} -> {:stop, reason, State.set(state, new_given)}
       {:error, reason} -> {:stop, reason, state}
     end
   end
 
   @doc false
+  def disconnected(reason, %{mod: mod, given: given} = state) do
+    new_state =
+      state
+      |> State.clear_waiting(&GenServer.reply(&1, {:error, :disconnected}))
+      |> State.disconnected()
+
+    case mod.handle_disconnected(reason, given) do
+      {:noreply, new_given} ->
+        {:ok, State.set(new_state, new_given)}
+
+      {:stop, reason, new_given} ->
+        {:stop, reason, State.set(new_state, new_given)}
+    end
+  end
+
+  @doc false
+  def handle_call({:"$hare_request", _payload, _routing_key, _opts}, _from, %{connected: false} = state) do
+    {:reply, {:error, :not_connected}, state}
+  end
   def handle_call({:"$hare_request", payload, routing_key, opts}, from, %{mod: mod, given: given} = state) do
     case mod.before_request(payload, routing_key, opts, from, given) do
       {:ok, new_given} ->
@@ -450,6 +531,9 @@ defmodule Hare.RPC.Client do
         handle_response(payload, meta, state)
 
       {:cancel_ok, _meta} ->
+        {:stop, {:shutdown, :cancelled}, state}
+
+      {:cancel, _meta} ->
         {:stop, :cancelled, state}
 
       {:return, payload, meta} ->
@@ -463,8 +547,10 @@ defmodule Hare.RPC.Client do
     do: handle_async(message, :handle_info, state)
 
   @doc false
-  def terminate(reason, %{mod: mod, given: given}),
-    do: mod.terminate(reason, given)
+  def terminate(reason, %{chan: chan, mod: mod, given: given}) do
+    if chan, do: Chan.unregister_return_handler(chan)
+    mod.terminate(reason, given)
+  end
 
   defp handle_mod_ready(meta, %{mod: mod, given: given} = state) do
     case mod.handle_ready(complete(meta, state), given) do

--- a/lib/hare/rpc/server/state.ex
+++ b/lib/hare/rpc/server/state.ex
@@ -14,8 +14,12 @@ defmodule Hare.RPC.Server.State do
            given:       given}
   end
 
-  def declared(%State{} = state, queue, exchange) do
+  def connected(%State{} = state, queue, exchange) do
     %{state | queue: queue, exchange: exchange}
+  end
+
+  def disconnected(%State{} = state) do
+    %{state | queue: nil, exchange: nil}
   end
 
   def set(%State{} = state, given) do

--- a/test/hare/consumer_test.exs
+++ b/test/hare/consumer_test.exs
@@ -10,6 +10,11 @@ defmodule Hare.ConsumerTest do
     def start_link(conn, config, pid),
       do: Consumer.start_link(__MODULE__, conn, config, pid)
 
+    def handle_connected(pid) do
+      send(pid, :connected)
+      {:noreply, pid}
+    end
+
     def handle_ready(meta, pid) do
       send(pid, {:ready, meta})
       {:noreply, pid}
@@ -58,6 +63,7 @@ defmodule Hare.ConsumerTest do
               bind: [routing_key: "qux"]]
 
     {:ok, consumer} = TestConsumer.start_link(conn, config, self())
+    assert_receive :connected
 
     send(consumer, {:consume_ok, %{bar: "baz"}})
     assert_receive {:ready, %{bar: "baz", queue: queue, exchange: exchange}}

--- a/test/hare/publisher_test.exs
+++ b/test/hare/publisher_test.exs
@@ -10,6 +10,11 @@ defmodule Hare.PublisherTest do
     def start_link(conn, config, pid),
       do: Publisher.start_link(__MODULE__, conn, config, pid)
 
+    def handle_connected(pid) do
+      send(pid, :connected)
+      {:noreply, pid}
+    end
+
     def publish(client, payload),
       do: Publisher.publish(client, payload)
     def publish(client, payload, routing_key, opts),
@@ -50,6 +55,7 @@ defmodule Hare.PublisherTest do
     config = []
 
     {:ok, publisher} = TestPublisher.start_link(conn, config, self())
+    assert_receive :connected
 
     payload     = "some data"
     routing_key = "the key"
@@ -77,6 +83,7 @@ defmodule Hare.PublisherTest do
                          opts: [durable: true]]]
 
     {:ok, publisher} = TestPublisher.start_link(conn, config, self())
+    assert_receive :connected
 
     send(publisher, :some_message)
     assert_receive {:info, :some_message}

--- a/test/hare/rpc/client_test.exs
+++ b/test/hare/rpc/client_test.exs
@@ -214,7 +214,7 @@ defmodule Hare.RPC.ClientTest do
   test "disconnect during request" do
     {:ok, conn} = Conn.start_link(config:  [],
                                   adapter: Adapter,
-                                  backoff: [100])
+                                  backoff: [500])
 
     config = [exchange: [name: "foo", type: :fanout]]
 

--- a/test/hare/rpc/server_test.exs
+++ b/test/hare/rpc/server_test.exs
@@ -108,7 +108,7 @@ defmodule Hare.RPC.ServerTest do
 
     Adapter.Backdoor.unlink(given_chan_1)
     Adapter.Backdoor.crash(given_chan_1)
-    Process.sleep(5)
+    Process.sleep(20)
 
     payload = "explicit - another message"
     meta    = %{reply_to: "response_queue", correlation_id: 11}

--- a/test/hare/rpc/server_test.exs
+++ b/test/hare/rpc/server_test.exs
@@ -10,6 +10,11 @@ defmodule Hare.RPC.ServerTest do
     def start_link(conn, config, pid),
       do: Server.start_link(__MODULE__, conn, config, pid)
 
+    def handle_connected(pid) do
+      send(pid, :connected)
+      {:noreply, pid}
+    end
+
     def handle_ready(meta, pid) do
       send(pid, {:ready, meta})
       {:noreply, pid}
@@ -57,6 +62,7 @@ defmodule Hare.RPC.ServerTest do
                       opts: [no_ack: true]]]
 
     {:ok, rpc_server} = EchoTestServer.start_link(conn, config, self())
+    assert_receive :connected
 
     send(rpc_server, {:consume_ok, %{bar: "baz"}})
     assert_receive {:ready, %{bar: "baz", queue: queue, exchange: exchange}}

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,1 @@
-ExUnit.start include: [amqp_server: true]
+ExUnit.start


### PR DESCRIPTION
Previously, `hare` wasn't able to gracefully handle RabbitMQ connection disruption. For example, `Hare.Consumer` called `Hare.Core.Conn.open_channel/2` on connection disruption and if connection couldn't be established in 5 seconds, consumer process would exit abnormally because of `GenServer.call` timeout. Connection failures should be expected and application should react on them properly.

This pull request changes the way `Hare.Actor` opens a channel on reconnection. By default `Hare.Actor` has status `:not_connected`. After initialization it opens a channel **synchronously**, like it was before, and sets its internal status to `:connected`.  When connection is disrupted, `Hare.Actor` process sets its internal status to `:not_connected`, invokes `disconnected/2` callback and requests channel from RabbitMQ connection **asynchronously**. The process is able to handle other messages while channel is being opened (it can take minutes or even hours during outages) which allows to avoid cascade GenServer timeouts. After channel is opened, `Hare.Actor` sets its internal status to `:connected` and invokes `connected/2` callback.

`Hare.Publisher`, `Hare.Consumer`, `Hare.RPC.Client` and `Hare.RPC.Server` react on `connected/disconnected` callbacks and change their internal state accordingly. For example, when user tries to make a request via disconnected `Hare.RPC.Client`, he will receive `{:error, :not_connected}` response immediately instead of crashing calling process because of timeout.